### PR TITLE
 let Django serialize your own custom class instances

### DIFF
--- a/db_file_storage/storage.py
+++ b/db_file_storage/storage.py
@@ -10,6 +10,8 @@ from django.core.files.storage import Storage
 from django.core.urlresolvers import reverse
 from django.utils.crypto import get_random_string
 from django.utils.http import urlencode
+from django.utils.deconstruct import deconstructible
+
 
 
 NAME_FORMAT_HINT = '<app>.<model>/<content_field>/<mimetype_field>' \
@@ -19,7 +21,7 @@ NAME_FORMAT_HINT = '<app>.<model>/<content_field>/<mimetype_field>' \
 class NameException(Exception):
     pass
 
-
+@deconstructible
 class DatabaseFileStorage(Storage):
     """File storage system that saves models' FileFields in the database.
 


### PR DESCRIPTION
 Using mysql as database backend,
in case we custom storage to an instance of db_file_storage. like below. 
inset = models.FileField(null=True, blank=True, help_text=u'嵌入临时截图',
                             upload_to='core.DBPicture/bytes/filename/mimetype',
                             storage=db_storage)

when  makemigrations, we failed at ValueError: Cannot serialize: <db_file_storage.storage.DatabaseFileStorage object at 0x104da1fd0>

To fix it.
add custom-deconstruct-method to resolve it.

for more
https://searchcode.com/file/114116265/django/core/files/storage.py
https://docs.djangoproject.com/ja/1.9/topics/migrations/#custom-deconstruct-method