### PR TITLE
more safe code, fixes rare but hard error

### DIFF
--- a/db_file_storage/form_widgets.py
+++ b/db_file_storage/form_widgets.py
@@ -32,7 +32,7 @@ def db_file_widget(cls):
 
     def get_context(self, name, value, attrs):
         context = super(cls, self).get_context(name, value, attrs)
-        if value:
+        if value and hasattr(value, 'url'):
             context['widget']['display'] = get_link_display(value.url)
         return context
     setattr(cls, 'get_context', get_context)


### PR DESCRIPTION
Hi,
I'm not sure with this change, but it solved for me rare but difficult error.
The text of error is here and they made same solution too:
encode/django-rest-framework#2759 (comment)

I think the change cannot make the solution worse.
And I often see this handling, like here:
https://djangosnippets.org/snippets/1580/ (render method)
www.cpume.com/question/ozgttooo-django-modelform-imagefield.html (render method)
https://stackoverflow.com/questions/10822111/django-modelform-imagefield?lq=1 (render method)

Thank you. Mirek