### PR TITLE
new management command: files2db

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ env:
     - DJANGO="django==1.9.13"
     - DJANGO="django==1.10.8"
     - DJANGO="django==1.11.9"
-    - DJANGO="django==2.0.1"
+    - DJANGO="django==2.0.2"
 matrix:
   exclude:
    - python: "2.7"
-     env: DJANGO="django==2.0.1"
+     env: DJANGO="django==2.0.2"
 install:
     - pip install Pillow
     - pip install $DJANGO

--- a/db_file_storage/form_widgets.py
+++ b/db_file_storage/form_widgets.py
@@ -32,7 +32,7 @@ def db_file_widget(cls):
 
     def get_context(self, name, value, attrs):
         context = super(cls, self).get_context(name, value, attrs)
-        if value:
+        if value and hasattr(value, 'url'):
             context['widget']['display'] = get_link_display(value.url)
         return context
     setattr(cls, 'get_context', get_context)

--- a/db_file_storage/management/commands/files2db.py
+++ b/db_file_storage/management/commands/files2db.py
@@ -21,16 +21,25 @@ class Command(BaseCommand):
         """
 
     def handle(self, *args, **options):
-        for app, tbl, fld in self.get_media_fields():
+        for app, tbl, model, fld in self.get_media_fields():
             if re.match(r'^\w+\.\w+/bytes/filename/mimetype$', fld.upload_to):
+                kwargs = {
+                    '{0}__gt'.format(fld.name): '',
+                }
+                qs_files = model.objects.select_for_update().filter(**kwargs).only(
+                        model._meta.pk.name, fld.name)
+                from pdb import set_trace; set_trace()
+
+                '''
                 self.stdout.write(app.label)
                 self.stdout.write(tbl)
                 self.stdout.write(fld.name)
                 self.stdout.write('')
+                '''
 
     def get_media_fields(self):
         for app in apps.get_app_configs():
             for tbl, model in app.models.items():
                 for fld in model._meta.get_fields():
                     if isinstance(fld, models.FileField):
-                        yield (app, tbl, fld)
+                        yield (app, tbl, model, fld)

--- a/db_file_storage/management/commands/files2db.py
+++ b/db_file_storage/management/commands/files2db.py
@@ -4,6 +4,8 @@ import re
 
 from django.apps import apps
 from django.db import models
+from django.conf import settings
+from django.core.files import File
 from django.core.management.base import BaseCommand
 
 
@@ -14,6 +16,15 @@ DB_PATTERN = re.compile(r'^\w+\.\w+/bytes/filename/mimetype$')
 
 class Command(BaseCommand):
     help = _("Copy separate media files from file system into database after the migration to db_file_storage.")
+
+    def __init__(self):
+        super(Command, self).__init__()
+        try:
+            self.MEDIA_ROOT = getattr(settings, 'MMEDIA_ROOT')
+        except AttributeError:
+            self.stderr.write(
+                    'Please configure MEDIA_ROOT in your settings. '
+                    'Otherwise files in standard file storage cannot be found.')
 
     def add_arguments(self, parser):
         parser.formatter_class = argparse.RawTextHelpFormatter
@@ -27,27 +38,40 @@ class Command(BaseCommand):
         for app, tbl, model, fld in self.get_media_fields():
             if re.match(DB_PATTERN, fld.upload_to):
                 kwargs = {
-                    '{0}__gt'.format(fld.name): '',
+                    '{0}__exact'.format(fld.name): '',
                 }
-                qs_files = model.objects.select_for_update().filter(**kwargs).only(
+                media_files = model.objects.select_for_update().exclude(**kwargs).only(
                         model._meta.pk.name, fld.name)
 
-                cnt_format_db = 0
-                for qs_file in qs_files:
-                    field_file = getattr(qs_file, fld.name)
-                    if re.match(DB_PATTERN, os.path.dirname(field_file.name)):
-                        cnt_format_db += 1
-                self.report(app, tbl, fld, 'db', len(qs_files), cnt_format_db)
+                cnt_non_db = cnt_format_unknown = 0
+                for media_file in media_files:
+                    field_file = getattr(media_file, fld.name)
+                    if not re.match(DB_PATTERN, os.path.dirname(field_file.name)):
+                        cnt_non_db += 1
+                        maybe_file = os.path.join(self.MEDIA_ROOT, field_file.name)
+                        if os.path.isfile(maybe_file):
+                            self.cp(field_file, maybe_file)
+                        else:
+                            cnt_format_unknown += 1
+                self.report(app, tbl, fld, 'db', len(media_files), cnt_non_db, cnt_format_unknown)
             else:
                 self.report(app, tbl, fld, 'other')
 
-    def report(self, app, tbl, fld, storage, cntfiles=None, cnt_format_db=0):
+    @staticmethod
+    def cp(field_file, media_file):
+        new_name = os.path.basename(media_file)
+        with open(media_file, 'rb') as f:
+            field_file.save(new_name, File(f))
+
+    def report(self, app, tbl, fld, storage, cntfiles=None, cnt_non_db=0, cnt_format_unknown=0):
         if cntfiles is not None:
-            storage = '%s - %s file(s) - %s std format - %s unknown - %s db format' % (
-                    storage, cntfiles, cntfiles - cnt_format_db, 0, cnt_format_db)
+            storage = '%s storage - contains %s file(s): %s std format - %s%s db format' % (
+                    storage, cntfiles, cnt_non_db - cnt_format_unknown,
+                    '%s unknown - ' if cnt_format_unknown else '', cntfiles - cnt_non_db)
         self.stdout.write('%s %s %s - %s' % (app.label, tbl, fld.name, storage))
 
-    def get_media_fields(self):
+    @staticmethod
+    def get_media_fields():
         for app in apps.get_app_configs():
             for tbl, model in app.models.items():
                 for fld in model._meta.get_fields():

--- a/db_file_storage/management/commands/files2db.py
+++ b/db_file_storage/management/commands/files2db.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
         parser.formatter_class = argparse.RawTextHelpFormatter
         parser.description = """
             ------------------------------------------------------------
-            Copy separate media files from file system into database after the migration to db_file_storage.
+            Use this after the migration to db_file_storage to copy earlier media files from file system into database.
 
             1. Migrate to db_file_storage first (change models, do makemigrations & migrate),
             2. Run './manage.py files2db' to copy earlier media into db.
@@ -69,7 +69,7 @@ class Command(BaseCommand):
                         else:
                             cnt_format_unknown += 1
                 total_std += cnt_non_db - cnt_format_unknown
-                self.report(app, tbl, fld, 'db', len(media_files), cnt_non_db, cnt_format_unknown)
+                self.report(app, tbl, fld, 'db', len(media_files), cnt_non_db, cnt_format_unknown, hideinfo=sandbox)
             else:
                 self.report(app, tbl, fld, 'non-db')
 
@@ -86,11 +86,11 @@ class Command(BaseCommand):
         with open(filename, 'rb') as f:
             field_file.save(new_name, File(f))
 
-    def report(self, app, tbl, fld, storage, cntfiles=None, cnt_non_db=0, cnt_format_unknown=0):
+    def report(self, app, tbl, fld, storage, cntfiles=None, cnt_non_db=0, cnt_format_unknown=0, hideinfo=True):
         storage += ' storage'
         if cntfiles is not None:
             cnt_std = cnt_non_db - cnt_format_unknown
-            if cnt_std and not sandbox:
+            if cnt_std and not hideinfo:
                 infomsg = ' (%s)' % _('will be copied into db')
             else:
                 infomsg = ''

--- a/db_file_storage/management/commands/files2db.py
+++ b/db_file_storage/management/commands/files2db.py
@@ -20,7 +20,7 @@ class Command(BaseCommand):
     def __init__(self):
         super(Command, self).__init__()
         try:
-            self.MEDIA_ROOT = getattr(settings, 'MMEDIA_ROOT')
+            self.MEDIA_ROOT = getattr(settings, 'MEDIA_ROOT')
         except AttributeError:
             self.stderr.write(
                     'Please configure MEDIA_ROOT in your settings. '

--- a/db_file_storage/management/commands/files2db.py
+++ b/db_file_storage/management/commands/files2db.py
@@ -1,0 +1,36 @@
+import argparse
+import re
+
+from django.apps import apps
+from django.db import models
+from django.core.management.base import BaseCommand
+
+
+_ = lambda x: x
+
+
+class Command(BaseCommand):
+    help = _("Copy separate media files from file system into database after the migration to db_file_storage.")
+
+    def add_arguments(self, parser):
+        parser.formatter_class = argparse.RawTextHelpFormatter
+        parser.description = """
+            ------------------------------------------------------------
+            Copy separate media files from file system into database after the migration to db_file_storage.
+            ------------------------------------------------------------
+        """
+
+    def handle(self, *args, **options):
+        for app, tbl, fld in self.get_media_fields():
+            if re.match(r'^\w+\.\w+/bytes/filename/mimetype$', fld.upload_to):
+                self.stdout.write(app.label)
+                self.stdout.write(tbl)
+                self.stdout.write(fld.name)
+                self.stdout.write('')
+
+    def get_media_fields(self):
+        for app in apps.get_app_configs():
+            for tbl, model in app.models.items():
+                for fld in model._meta.get_fields():
+                    if isinstance(fld, models.FileField):
+                        yield (app, tbl, fld)

--- a/db_file_storage/management/commands/files2db.py
+++ b/db_file_storage/management/commands/files2db.py
@@ -89,8 +89,13 @@ class Command(BaseCommand):
     def report(self, app, tbl, fld, storage, cntfiles=None, cnt_non_db=0, cnt_format_unknown=0):
         storage += ' storage'
         if cntfiles is not None:
-            storage += ' - contains %s file(s): %s std format - %s%s db format' % (
-                    cntfiles, cnt_non_db - cnt_format_unknown,
+            cnt_std = cnt_non_db - cnt_format_unknown
+            if cnt_std and not sandbox:
+                infomsg = ' (%s)' % _('will be copied into db')
+            else:
+                infomsg = ''
+            storage += ' - contains %s file(s): %s std format%s - %s%s db format' % (
+                    cntfiles, cnt_std, infomsg,
                     '%s unknown - ' % cnt_format_unknown if cnt_format_unknown else '', cntfiles - cnt_non_db)
         self.stdout.write('%s %s %s - %s' % (app.label, tbl, fld.name, storage))
 

--- a/db_file_storage/management/commands/files2db.py
+++ b/db_file_storage/management/commands/files2db.py
@@ -67,7 +67,7 @@ class Command(BaseCommand):
         if cntfiles is not None:
             storage = '%s storage - contains %s file(s): %s std format - %s%s db format' % (
                     storage, cntfiles, cnt_non_db - cnt_format_unknown,
-                    '%s unknown - ' if cnt_format_unknown else '', cntfiles - cnt_non_db)
+                    '%s unknown - ' % cnt_format_unknown if cnt_format_unknown else '', cntfiles - cnt_non_db)
         self.stdout.write('%s %s %s - %s' % (app.label, tbl, fld.name, storage))
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='0.5.0',
     author='Victor Oliveira da Silva',
     author_email='victor_o_silva@hotmail.com',
-    packages=['db_file_storage'],
+    packages=['db_file_storage', 'db_file_storage.management'],
     package_data={
         'db_file_storage': ['templates/db_file_storage/widgets/*']
     },

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='0.5.0',
     author='Victor Oliveira da Silva',
     author_email='victor_o_silva@hotmail.com',
-    packages=['db_file_storage', 'db_file_storage.management'],
+    packages=['db_file_storage', 'db_file_storage.management', 'db_file_storage.management.commands'],
     package_data={
         'db_file_storage': ['templates/db_file_storage/widgets/*']
     },


### PR DESCRIPTION
After the migration to db_file_storage the 'files2db' command will copy earlier files from standard storage into database.

I know it could be done better, probably with specialized package which moves/copies media files between different storages. However I think it could be useful so too.

If you will accept it, I can add something into docs. Or just add yourself something from 'parser.description = ....' command in files2db. Maybe it would be better, because I am not native speaker and the english should be improved.

(Just 1 file is added; the change in form_widgets.py is old, but I am not able remove it from PR, I have merged upstream to late.)

Best regards,
Mirek
