### PR TITLE
Fix django 4.0 deprecations

### DIFF
--- a/db_file_storage/views.py
+++ b/db_file_storage/views.py
@@ -1,6 +1,11 @@
 # third party
 from django.http import HttpResponse, HttpResponseBadRequest
-from django.utils.translation import ugettext as _
+
+try:
+    from django.utils.translation import ugettext as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _    
+
 from wsgiref.util import FileWrapper
 # project
 from db_file_storage.storage import DatabaseFileStorage


### PR DESCRIPTION
The `ugettext ` has deprecated in `django` 4.0.

https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0