### PR TITLE
🩹 fix: Disambiguate Windows OS Separator

### DIFF
--- a/db_file_storage/storage.py
+++ b/db_file_storage/storage.py
@@ -67,6 +67,8 @@ class DatabaseFileStorage(Storage):
         return final_name
 
     def _get_storage_attributes(self, name):
+        if os.sep != '/':  # Windows fix (see a6d4707) # pragma: no cover
+            name = name.replace('/', os.sep)
         try:
             (
                 model_class_path,


### PR DESCRIPTION
## Description
Windows uses '\' (back-slash) rather than '/' (forward-slash) in its filepaths. This commit resolves #29 by replacing to correct slash based on the operating system


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Resolves #29