### PR TITLE
Fix field separator was not replaced consistently when using Windows

### DIFF
--- a/db_file_storage/storage.py
+++ b/db_file_storage/storage.py
@@ -48,6 +48,10 @@ class DatabaseFileStorage(Storage):
         return ContentFile(file_buffer)
 
     def _get_unique_filename(self, model_cls, filename_field, filename):
+        # Also patch the separator upon creation of a file.
+        if os.sep != '/':  # Windows fix (see a6d4707) # pragma: no cover
+            filename = filename.replace('/', os.sep)
+
         final_name = filename
 
         if ('.' in filename.rsplit(os.sep, 1)[-1]):


### PR DESCRIPTION
When using Windows, the path separator is switched from `/` to `\\`. This is done everywhere except in the creation of a file. Because of that, the file is saved with `/` as separator but when reading the file it is trying to read it with `\\` as a separator, causing the file to be not found. This PR fixes that minor error.